### PR TITLE
[Feat] 헤더 컴포넌트 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,1 +1,12 @@
-console.log("hello world");
+import headerComponent from "./views/components/header";
+
+(() => {
+  const appTemplate = `
+  <header id="header"></header>
+  <main id="main"></main>
+  <footer id="footer"></footer>
+`;
+  const app = document.getElementById("app");
+  app.innerHTML = appTemplate;
+})();
+headerComponent();

--- a/src/views/components/header/index.css
+++ b/src/views/components/header/index.css
@@ -1,0 +1,28 @@
+#header_container {
+  max-width: 1140px;
+  margin: 0 auto;
+  height: 60px;
+  padding: 0 46px;
+  box-sizing: border-box;
+}
+
+a {
+  text-decoration: none;
+}
+
+#header_inner_container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+#header_logo_container {
+  max-width: 180px;
+  width: 100%;
+  display: flex;
+}
+
+.logoName {
+  color: black;
+}

--- a/src/views/components/header/index.js
+++ b/src/views/components/header/index.js
@@ -1,0 +1,20 @@
+import "./index.css";
+
+const headerTemplate = `
+<header id="header_container">
+  <div id="header_inner_container">
+    <a href="/">
+      <div id="header_logo_container">
+        <h1 class="logoName">멘토링 회고록</h1>
+      </div>
+    </a>
+  </div>
+</header>
+`;
+
+const headerComponent = () => {
+  const header = document.getElementById("header");
+  header.innerHTML = headerTemplate;
+};
+
+export default headerComponent;


### PR DESCRIPTION
# 설명
 - 추후 화면에 보여질 헤더를 컴포넌트로 구현하였습니다.
 - 3개 의 컨테이너로 나뉘어 css를 적용하였습니다.
## 무슨 종류의 PR인지?

- [X] 🕹️ Feat
- [ ] 📌 Fix
- [ ] 🔖 Documentation Update
- [ ] 🎨 Style
- [ ] 🔎 Code Refactor
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

# 어떻게 테스트 되었는가?

- [ ] 테스트 코드 작성
- [X] 로컬환경에서 수동 테스트 진행

> 캡쳐화면
<img width="1512" alt="스크린샷 2024-02-25 오후 3 02 08" src="https://github.com/andyhan-23/retrospect-blog/assets/98483125/271215d8-8c4b-4a4d-9828-8cc0862605b2">

# 티켓 번호
[JAE_78](https://linear.app/jaehyeok/issue/JAE-78/%5B1%5D-%ED%97%A4%EB%8D%94-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8)